### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,7 +162,7 @@ AC_MSG_RESULT($enable_debug)
 dnl -------------------------------------------------------------------
 dnl Get the date for the man-page and substitute it there and anywhere.
 dnl -------------------------------------------------------------------
-MY_DATE=`date +%Y-%m-%d`
+MY_DATE=`date -u -r ChangeLog +%Y-%m-%d`
 
 AC_SUBST(MY_DATE)
 


### PR DESCRIPTION
that gets put into the man page
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

And use UTC to be independent of timezones.